### PR TITLE
Enhancement: Use ruleset for PHP 7.3

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -26,7 +26,7 @@ $license = License\Type\MIT::markdown(
 
 $license->save();
 
-$config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($license->header()));
+$config = Config\Factory::fromRuleSet(new Config\RuleSet\Php73($license->header()));
 
 $config->getFinder()
     ->ignoreDotFiles(false)


### PR DESCRIPTION
This PR

* [x] uses the ruleset for PHP 7.3 for `friendsofphp/php-cs-fixer`