### PR TITLE
Fix: Consistently indent YAML files with 2 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,9 @@ indent_size = 2
 [*.neon]
 indent_style = tab
 
+[*.yaml]
+indent_size = 2
+
 [*.yml]
 indent_size = 2
 

--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -1,19 +1,19 @@
 framework:
-    cache:
-        # Unique name of your app: used to compute stable namespaces for cache keys.
-        #prefix_seed: your_vendor_name/app_name
+  cache:
+    # Unique name of your app: used to compute stable namespaces for cache keys.
+    #prefix_seed: your_vendor_name/app_name
 
-        # The "app" cache stores to the filesystem by default.
-        # The data in this cache should persist between deploys.
-        # Other options include:
+    # The "app" cache stores to the filesystem by default.
+    # The data in this cache should persist between deploys.
+    # Other options include:
 
-        # Redis
-        #app: cache.adapter.redis
-        #default_redis_provider: redis://localhost
+    # Redis
+    #app: cache.adapter.redis
+    #default_redis_provider: redis://localhost
 
-        # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
-        #app: cache.adapter.apcu
+    # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
+    #app: cache.adapter.apcu
 
-        # Namespaced pools use the above "app" backend by default
-        #pools:
-            #my.dedicated.cache: null
+    # Namespaced pools use the above "app" backend by default
+    #pools:
+      #my.dedicated.cache: null

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -1,16 +1,16 @@
 framework:
-    secret: '%env(APP_SECRET)%'
-    #csrf_protection: true
-    #http_method_override: true
+  secret: '%env(APP_SECRET)%'
+  #csrf_protection: true
+  #http_method_override: true
 
-    # Enables session support. Note that the session will ONLY be started if you read or write from it.
-    # Remove or comment this section to explicitly disable session support.
-    session:
-        handler_id: null
-        cookie_secure: auto
-        cookie_samesite: lax
+  # Enables session support. Note that the session will ONLY be started if you read or write from it.
+  # Remove or comment this section to explicitly disable session support.
+  session:
+    handler_id: null
+    cookie_secure: auto
+    cookie_samesite: lax
 
-    #esi: true
-    #fragments: true
-    php_errors:
-        log: true
+  #esi: true
+  #fragments: true
+  php_errors:
+    log: true

--- a/config/packages/prod/routing.yaml
+++ b/config/packages/prod/routing.yaml
@@ -1,3 +1,3 @@
 framework:
-    router:
-        strict_requirements: null
+  router:
+    strict_requirements: null

--- a/config/packages/routing.yaml
+++ b/config/packages/routing.yaml
@@ -1,3 +1,3 @@
 framework:
-    router:
-        utf8: true
+  router:
+    utf8: true

--- a/config/packages/test/framework.yaml
+++ b/config/packages/test/framework.yaml
@@ -1,4 +1,4 @@
 framework:
-    test: true
-    session:
-        storage_id: session.storage.mock_file
+  test: true
+  session:
+    storage_id: session.storage.mock_file

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,3 +1,3 @@
 #index:
-#    path: /
-#    controller: Ergebnis\Application\Controller\DefaultController::index
+#  path: /
+#  controller: Ergebnis\Application\Controller\DefaultController::index

--- a/config/routes/annotations.yaml
+++ b/config/routes/annotations.yaml
@@ -1,7 +1,7 @@
 controllers:
-    resource: ../../src/Controller/
-    type: annotation
+  resource: ../../src/Controller/
+  type: annotation
 
 kernel:
-    resource: ../../src/Kernel.php
-    type: annotation
+  resource: ../../src/Kernel.php
+  type: annotation

--- a/config/routes/dev/framework.yaml
+++ b/config/routes/dev/framework.yaml
@@ -1,3 +1,3 @@
 _errors:
-    resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
-    prefix: /_error
+  resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+  prefix: /_error

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,22 +6,22 @@
 parameters:
 
 services:
-    # default configuration for services in *this* file
-    _defaults:
-        autowire: true      # Automatically injects dependencies in your services.
-        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+  # default configuration for services in *this* file
+  _defaults:
+    autowire: true      # Automatically injects dependencies in your services.
+    autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
 
-    # makes classes in src/ available to be used as services
-    # this creates a service per class whose id is the fully-qualified class name
-    Ergebnis\Application\:
-        resource: '../src/*'
-        exclude: '../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}'
+  # makes classes in src/ available to be used as services
+  # this creates a service per class whose id is the fully-qualified class name
+  Ergebnis\Application\:
+    resource: '../src/*'
+    exclude: '../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}'
 
-    # controllers are imported separately to make sure services can be injected
-    # as action arguments even if you don't extend any base controller class
-    Ergebnis\Application\Controller\:
-        resource: '../src/Controller'
-        tags: ['controller.service_arguments']
+  # controllers are imported separately to make sure services can be injected
+  # as action arguments even if you don't extend any base controller class
+  Ergebnis\Application\Controller\:
+    resource: '../src/Controller'
+    tags: ['controller.service_arguments']
 
-    # add more service definitions when explicit configuration is needed
-    # please note that last definitions always *replace* previous ones
+  # add more service definitions when explicit configuration is needed
+  # please note that last definitions always *replace* previous ones


### PR DESCRIPTION
This PR

* [x] consistently indents YAML files with 2 spaces

💁‍♂ Indentation with 4 spaces is particularly awkward when configuring lists of objects with an indentation of 4 spaces.