### PR TITLE
Fix: Use trailing slash when referencing directory

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -85,7 +85,7 @@ jobs:
         run: "composer dump-env ${{ env.APP_ENV }}"
 
       - name: "Lint YAML files"
-        run: "bin/console lint:yaml .dependabot .github/ config/"
+        run: "bin/console lint:yaml .dependabot/ .github/ config/"
 
   dependency-analysis:
     name: "Dependency Analysis"


### PR DESCRIPTION
This PR

* [x] uses a trailing slash when referencing a directory