### PR TITLE
Fix: CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @ergebnis-bot
-* @localheinz
+* @ergebnis-bot @localheinz


### PR DESCRIPTION
This PR

* [x] fixes `CODEOWNERS`