### PR TITLE
Fix: Allow extension of Symfony\Component\HttpKernel\Kernel

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: config/bootstrap.php
 
 		-
-			message: "#^Class \"Ergebnis\\\\Application\\\\Kernel\" is not allowed to extend \"Symfony\\\\Component\\\\HttpKernel\\\\Kernel\"\\.$#"
-			count: 1
-			path: src/Kernel.php
-
-		-
 			message: "#^Method Ergebnis\\\\Application\\\\Kernel\\:\\:configureContainer\\(\\) has a parameter \\$container with a type declaration of Symfony\\\\Component\\\\DependencyInjection\\\\ContainerBuilder, but containers should not be injected\\.$#"
 			count: 1
 			path: src/Kernel.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,9 @@ includes:
 
 parameters:
 	checkMissingIterableValueType: false
+	ergebnis:
+		classesAllowedToBeExtended:
+			- Symfony\Component\HttpKernel\Kernel
 	inferPrivatePropertyTypeFromConstructor: true
 	level: max
 	paths:


### PR DESCRIPTION
This PR

* [x] allows extension of `Symfony\Component\HttpKernel\Kernel`