### PR TITLE
Fix: Use RoutingConfigurator instead of deprecated RouteCollectionBuilder

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -35,8 +35,3 @@ parameters:
 			count: 1
 			path: src/Kernel.php
 
-		-
-			message: "#^Parameter \\$routes of method Ergebnis\\\\Application\\\\Kernel\\:\\:configureRoutes\\(\\) has typehint with deprecated class Symfony\\\\Component\\\\Routing\\\\RouteCollectionBuilder\\:\nsince Symfony 5\\.1, use RoutingConfigurator instead$#"
-			count: 1
-			path: src/Kernel.php
-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.12.1@9b860214d58c48b5cbe99bdb17914d0eb723c9cd">
+<files psalm-version="3.13.1@afd8874a9e4562eac42a02de90e42e430c3a1db1">
   <file src="bin/console">
     <MixedArgument occurrences="1">
       <code>$_SERVER['APP_ENV']</code>
@@ -35,12 +35,6 @@
     </MixedAssignment>
   </file>
   <file src="src/Kernel.php">
-    <DeprecatedClass occurrences="4">
-      <code>Routing\RouteCollectionBuilder</code>
-      <code>$routes-&gt;import($confDir . '/{routes}/' . $this-&gt;environment . '/*' . self::CONFIG_EXTS, '/', 'glob')</code>
-      <code>$routes-&gt;import($confDir . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob')</code>
-      <code>$routes-&gt;import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob')</code>
-    </DeprecatedClass>
     <MixedAssignment occurrences="2">
       <code>$contents</code>
       <code>$envs</code>

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -55,12 +55,12 @@ final class Kernel extends HttpKernel\Kernel
         $loader->load($confDir . '/{services}_' . $this->environment . self::CONFIG_EXTS, 'glob');
     }
 
-    protected function configureRoutes(Routing\RouteCollectionBuilder $routes): void
+    protected function configureRoutes(Routing\Loader\Configurator\RoutingConfigurator $routingConfigurator): void
     {
         $confDir = $this->getProjectDir() . '/config';
 
-        $routes->import($confDir . '/{routes}/' . $this->environment . '/*' . self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($confDir . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
+        $routingConfigurator->import($confDir . '/{routes}/' . $this->environment . '/*' . self::CONFIG_EXTS);
+        $routingConfigurator->import($confDir . '/{routes}/*' . self::CONFIG_EXTS);
+        $routingConfigurator->import($confDir . '/{routes}' . self::CONFIG_EXTS);
     }
 }


### PR DESCRIPTION
This PR

* [x] uses the `RoutingConfigurator` instead of the deprecated `RouteCollectionBuilder`