### PR TITLE
Enhancement: Update symfony.lock when @dependabot updates dependencies

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -96,6 +96,18 @@ $ make mutation-tests
 
 to run mutation tests.
 
+## Symfony
+
+We are using [`symfony/flex`](https://github.com/symfony/flex) to integrate packages into the application.
+
+Run
+
+```sh
+$ make symfony
+```
+
+to synchronize recipes.
+
 ## Extra lazy?
 
 Run

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -19,6 +19,7 @@ branches:
           - "Dependency Analysis (7.4, locked)"
           - "Mutation Tests (7.4, locked)"
           - "Static Code Analysis (7.4, locked)"
+          - "Symfony Flex (7.4, locked)"
           - "Tests (7.4, locked)"
         strict: false
       restrictions:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,10 +10,87 @@ on: # yamllint disable-line rule:truthy
 
 env:
   APP_ENV: "test"
+  ERGEBNIS_BOT_EMAIL: "bot@ergebn.is"
   ERGEBNIS_BOT_NAME: "ergebnis-bot"
   PHP_EXTENSIONS: "mbstring"
 
 jobs:
+  symfony-flex:
+    name: "Symfony Flex"
+
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.4"
+
+        dependencies:
+          - "locked"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2.3.2"
+        with:
+          ref: "${{ github.head_ref }}"
+          token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
+
+      - name: "Install PHP with extensions"
+        uses: "shivammathur/setup-php@2.4.3"
+        with:
+          coverage: "none"
+          extensions: "${{ env.PHP_EXTENSIONS }}"
+          php-version: "${{ matrix.php-version }}"
+
+      - name: "Determine composer cache directory"
+        uses: "./.github/actions/composer/composer/determine-cache-directory"
+
+      - name: "Cache dependencies installed with composer"
+        uses: "actions/cache@v2.1.1"
+        with:
+          path: "${{ env.COMPOSER_CACHE_DIR }}"
+          key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
+
+      - name: "Install ${{ matrix.dependencies }} dependencies with composer"
+        uses: "./.github/actions/composer/composer/install"
+        with:
+          dependencies: "${{ matrix.dependencies }}"
+
+      - name: "Synchronize symfony/flex recipes"
+        run: "composer symfony:sync-recipes"
+
+      - name: "Commit symfony.lock"
+        if: >
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.draft == false && (
+            github.event.action == 'opened' ||
+            github.event.action == 'reopened' ||
+            github.event.action == 'synchronize'
+          ) && (
+            (github.actor == 'dependabot[bot]' && startsWith(github.event.pull_request.title, 'composer(deps)')) ||
+            (github.actor == 'dependabot[bot]' && startsWith(github.event.pull_request.title, 'composer(deps-dev)'))
+          )
+        uses: "stefanzweifel/git-auto-commit-action@v4.4.1"
+        with:
+          branch: "${{ github.head_ref }}"
+          commit_author: "${{ env.ERGEBNIS_BOT_NAME }} <${{ env.ERGEBNIS_BOT_EMAIL }}>"
+          commit_message: "Fix: Update symfony.lock"
+          commit_user_email: "${{ env.ERGEBNIS_BOT_EMAIL }}"
+          commit_user_name: "${{ env.ERGEBNIS_BOT_NAME }}"
+          file_pattern: "symfony.lock"
+
+      - name: "Verify that symfony.lock is up-to-date"
+        if: "github.actor != 'dependabot[bot]'"
+        run: |
+          diff=$(git diff symfony.lock)
+
+          if [[ "${diff}" != "" ]]; then
+            echo "::error file=symfony.lock::symfony.lock is not up-to-date."
+
+            exit 1
+          fi
+
   coding-standards:
     name: "Coding Standards"
 
@@ -394,6 +471,7 @@ jobs:
       - "dependency-analysis"
       - "mutation-tests"
       - "static-code-analysis"
+      - "symfony-flex"
       - "tests"
 
     if: >

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ tests: vendor cache environment doctrine ## Runs auto-review, unit, integration,
 	vendor/bin/phpunit --configuration=test/Integration/phpunit.xml
 	vendor/bin/phpunit --configuration=test/Functional/phpunit.xml
 
+.PHONY: symfony
+symfony: vendor ## Synchronizes symfony recipes
+	composer symfony:sync-recipes
+
 vendor: composer.json composer.lock
 	composer validate --strict
 	composer install --no-interaction --no-progress --no-suggest

--- a/symfony.lock
+++ b/symfony.lock
@@ -8,6 +8,9 @@
     "brick/math": {
         "version": "0.8.15"
     },
+    "composer/package-versions-deprecated": {
+        "version": "1.11.99"
+    },
     "composer/semver": {
         "version": "1.5.1"
     },
@@ -185,6 +188,9 @@
     },
     "migrify/config-transformer": {
         "version": "v0.3.24"
+    },
+    "migrify/php-config-printer": {
+        "version": "v0.3.31"
     },
     "myclabs/deep-copy": {
         "version": "1.9.5"


### PR DESCRIPTION
This PR

* [x] updates `symfony.lock` when @dependabot updated dependencies or fails when `symfony.lock` is not up-to-date
* [x] adds a `symfony` target to `Makefile` to synchronize recipes
* [x] runs `make symfony`