### PR TITLE
Fix: Let @ergebnis-bot merge updates to symfony.lock

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -485,6 +485,7 @@ jobs:
         (github.actor == 'dependabot[bot]' && startsWith(github.event.pull_request.title, 'composer(deps-dev)')) ||
         (github.actor == 'dependabot[bot]' && startsWith(github.event.pull_request.title, 'github-actions(deps)')) ||
         (github.actor == 'ergebnis-bot' && github.event.pull_request.title == 'Enhancement: Update license year') ||
+        (github.actor == 'ergebnis-bot' && github.event.pull_request.title == 'Fix: Update symfony.lock') ||
         (github.actor == 'localheinz' && contains(github.event.pull_request.labels.*.name, 'merge'))
       )
 


### PR DESCRIPTION
This PR

* [x] lets @ergebnis-bot merge updates to `symfony.lock`