### PR TITLE
Fix: Synchronize with symfony/website-skeleton

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -4,6 +4,7 @@
 use Ergebnis\Application;
 use Symfony\Bundle\FrameworkBundle;
 use Symfony\Component\Console;
+use Symfony\Component\Dotenv;
 use Symfony\Component\ErrorHandler;
 
 if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
@@ -14,8 +15,8 @@ if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
 
 require \dirname(__DIR__) . '/vendor/autoload.php';
 
-if (!\class_exists(FrameworkBundle\Console\Application::class)) {
-    throw new LogicException('You need to add "symfony/framework-bundle" as a Composer dependency.');
+if (!\class_exists(FrameworkBundle\Console\Application::class) || !\class_exists(Dotenv\Dotenv::class)) {
+    throw new LogicException('You need to add "symfony/framework-bundle" as a Composer dependencies.');
 }
 
 $input = new Console\Input\ArgvInput();
@@ -28,7 +29,7 @@ if ($input->hasParameterOption('--no-debug', true)) {
     \putenv('APP_DEBUG=' . $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
 }
 
-require \dirname(__DIR__) . '/config/bootstrap.php';
+(new Dotenv\Dotenv())->bootEnv(\dirname(__DIR__) . '/.env');
 
 if ($_SERVER['APP_DEBUG']) {
     \umask(0000);

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.14.2@3538fe1955d47f6ee926c0769d71af6db08aa488">
+<files psalm-version="3.16@d03e5ef057d6adc656c0ff7e166c50b73b4f48f3">
   <file src="bin/console">
     <MixedArgument occurrences="1">
       <code>$_SERVER['APP_ENV']</code>
     </MixedArgument>
     <MixedAssignment occurrences="3">
-      <code>$env</code>
       <code>$_ENV['APP_ENV']</code>
       <code>$_SERVER['APP_ENV']</code>
+      <code>$env</code>
     </MixedAssignment>
     <MixedOperand occurrences="1">
       <code>$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env</code>
@@ -17,8 +17,8 @@
     <MixedAssignment occurrences="4">
       <code>$_ENV[$k]</code>
       <code>$_ENV['APP_ENV']</code>
-      <code>$_SERVER['APP_ENV']</code>
       <code>$_SERVER['APP_DEBUG']</code>
+      <code>$_SERVER['APP_ENV']</code>
     </MixedAssignment>
     <RedundantCondition occurrences="1">
       <code>\is_array($env = include \dirname(__DIR__) . '/.env.local.php')</code>
@@ -26,12 +26,12 @@
   </file>
   <file src="public/index.php">
     <MixedArgument occurrences="2">
-      <code>$trustedProxies</code>
       <code>$_SERVER['APP_ENV']</code>
+      <code>$trustedProxies</code>
     </MixedArgument>
     <MixedAssignment occurrences="2">
-      <code>$trustedProxies</code>
       <code>$trustedHosts</code>
+      <code>$trustedProxies</code>
     </MixedAssignment>
   </file>
   <file src="src/Kernel.php">

--- a/public/index.php
+++ b/public/index.php
@@ -12,10 +12,13 @@ declare(strict_types=1);
  */
 
 use Ergebnis\Application;
+use Symfony\Component\Dotenv;
 use Symfony\Component\ErrorHandler;
 use Symfony\Component\HttpFoundation;
 
-require \dirname(__DIR__) . '/config/bootstrap.php';
+require \dirname(__DIR__) . '/vendor/autoload.php';
+
+(new Dotenv\Dotenv())->bootEnv(\dirname(__DIR__) . '/.env');
 
 if ($_SERVER['APP_DEBUG']) {
     \umask(0000);


### PR DESCRIPTION
This PR

* [x] synchronizes with [`symfony/website-skeleton`](https://github.com/symfony/website-skeleton)

💁‍♂️ To be honest, I have no idea what the idea is behind creating repositories that contain only a `composer.json` and then - per some magic I am not interested in - pull in application code from somewhere else. Where do I find this code so I can inspect the changes that were made and why?

This is too much magic for my taste.