### PR TITLE
Fix: Include bin/ directory when running static code analysis

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
 	inferPrivatePropertyTypeFromConstructor: true
 	level: max
 	paths:
+		- bin/
 		- config/
 		- src/
 		- test/

--- a/psalm.xml
+++ b/psalm.xml
@@ -23,6 +23,7 @@
     </plugins>
 
     <projectFiles>
+        <directory name="bin/" />
         <directory name="config/" />
         <directory name="src/" />
         <directory name="test/" />


### PR DESCRIPTION
This PR

* [x] includes the `bin/` directory when running a static code analysis
