### PR TITLE
Fix: Clean up the code shipped with symfony/website-skeleton

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -7,7 +7,7 @@ use Symfony\Component\Console;
 use Symfony\Component\Dotenv;
 use Symfony\Component\ErrorHandler;
 
-if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+if (!\in_array(\PHP_SAPI, ['cli', 'embed', 'phpdbg'], true)) {
     echo 'Warning: The console should be invoked via the CLI version of PHP, not the ' . \PHP_SAPI . ' SAPI' . \PHP_EOL;
 }
 

--- a/bin/console
+++ b/bin/console
@@ -34,10 +34,12 @@ if (null !== $environment) {
 }
 
 if ($input->hasParameterOption('--no-debug', true)) {
-    $_SERVER['APP_DEBUG'] = '0';
-    $_ENV['APP_DEBUG'] = '0';
+    $debug = '0';
 
-    \putenv('APP_DEBUG=' . '0');
+    $_SERVER['APP_DEBUG'] = $debug;
+    $_ENV['APP_DEBUG'] = $debug;
+
+    \putenv('APP_DEBUG=' . $debug);
 }
 
 (new Dotenv\Dotenv())->bootEnv(__DIR__ . '/../.env');

--- a/bin/console
+++ b/bin/console
@@ -17,7 +17,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $input = new Console\Input\ArgvInput();
 
-$env = $input->getParameterOption(
+$environment = $input->getParameterOption(
     [
         '--env',
         '-e'
@@ -26,8 +26,8 @@ $env = $input->getParameterOption(
     true
 );
 
-if (null !== $env) {
-    \putenv('APP_ENV=' . $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
+if (null !== $environment) {
+    \putenv('APP_ENV=' . $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $environment);
 }
 
 if ($input->hasParameterOption('--no-debug', true)) {

--- a/bin/console
+++ b/bin/console
@@ -17,7 +17,9 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $input = new Console\Input\ArgvInput();
 
-if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
+$env = $input->getParameterOption(['--env', '-e'], null, true);
+
+if (null !== $env) {
     \putenv('APP_ENV=' . $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
 }
 

--- a/bin/console
+++ b/bin/console
@@ -34,7 +34,10 @@ if (null !== $environment) {
 }
 
 if ($input->hasParameterOption('--no-debug', true)) {
-    \putenv('APP_DEBUG=' . $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
+    $_SERVER['APP_DEBUG'] = '0';
+    $_ENV['APP_DEBUG'] = '0';
+
+    \putenv('APP_DEBUG=' . '0');
 }
 
 (new Dotenv\Dotenv())->bootEnv(__DIR__ . '/../.env');

--- a/bin/console
+++ b/bin/console
@@ -20,14 +20,17 @@ $input = new Console\Input\ArgvInput();
 $environment = $input->getParameterOption(
     [
         '--env',
-        '-e'
+        '-e',
     ],
     null,
     true
 );
 
 if (null !== $environment) {
-    \putenv('APP_ENV=' . $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $environment);
+    $_SERVER['APP_ENV'] = $environment;
+    $_ENV['APP_ENV'] = $environment;
+
+    \putenv('APP_ENV=' . $environment);
 }
 
 if ($input->hasParameterOption('--no-debug', true)) {

--- a/bin/console
+++ b/bin/console
@@ -17,7 +17,14 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $input = new Console\Input\ArgvInput();
 
-$env = $input->getParameterOption(['--env', '-e'], null, true);
+$env = $input->getParameterOption(
+    [
+        '--env',
+        '-e'
+    ],
+    null,
+    true
+);
 
 if (null !== $env) {
     \putenv('APP_ENV=' . $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);

--- a/bin/console
+++ b/bin/console
@@ -42,7 +42,9 @@ if ($input->hasParameterOption('--no-debug', true)) {
     \putenv('APP_DEBUG=' . $debug);
 }
 
-(new Dotenv\Dotenv())->bootEnv(__DIR__ . '/../.env');
+$dotEnv = new Dotenv\Dotenv();
+
+$dotEnv->bootEnv(__DIR__ . '/../.env');
 
 if ($_SERVER['APP_DEBUG']) {
     \umask(0000);

--- a/bin/console
+++ b/bin/console
@@ -15,10 +15,6 @@ if (!\in_array(\PHP_SAPI, ['cli', 'embed', 'phpdbg'], true)) {
 
 require __DIR__ . '/../vendor/autoload.php';
 
-if (!\class_exists(FrameworkBundle\Console\Application::class) || !\class_exists(Dotenv\Dotenv::class)) {
-    throw new LogicException('You need to add "symfony/framework-bundle" as a Composer dependencies.');
-}
-
 $input = new Console\Input\ArgvInput();
 
 if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {

--- a/bin/console
+++ b/bin/console
@@ -13,7 +13,7 @@ if (!\in_array(\PHP_SAPI, ['cli', 'embed', 'phpdbg'], true)) {
 
 \set_time_limit(0);
 
-require \dirname(__DIR__) . '/vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 if (!\class_exists(FrameworkBundle\Console\Application::class) || !\class_exists(Dotenv\Dotenv::class)) {
     throw new LogicException('You need to add "symfony/framework-bundle" as a Composer dependencies.');
@@ -29,7 +29,7 @@ if ($input->hasParameterOption('--no-debug', true)) {
     \putenv('APP_DEBUG=' . $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
 }
 
-(new Dotenv\Dotenv())->bootEnv(\dirname(__DIR__) . '/.env');
+(new Dotenv\Dotenv())->bootEnv(__DIR__ . '/../.env');
 
 if ($_SERVER['APP_DEBUG']) {
     \umask(0000);

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,10 +17,10 @@ require __DIR__ . '/../vendor/autoload.php';
 
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
-$env = include __DIR__ . '/../.env.local.php';
+$environmentVariables = include __DIR__ . '/../.env.local.php';
 
-if (\is_array($env) && (!isset($env['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV']) === $env['APP_ENV'])) {
-    foreach ($env as $k => $v) {
+if (\is_array($environmentVariables) && (!isset($environmentVariables['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $environmentVariables['APP_ENV']) === $environmentVariables['APP_ENV'])) {
+    foreach ($environmentVariables as $k => $v) {
         $_ENV[$k] = $_ENV[$k] ?? (isset($_SERVER[$k]) && 0 !== \mb_strpos($k, 'HTTP_') ? $_SERVER[$k] : $v);
     }
 } elseif (!\class_exists(Dotenv::class)) {

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -25,7 +25,9 @@ if (\is_array($environmentVariables) && (!isset($environmentVariables['APP_ENV']
     }
 } else {
     // load all the .env files
-    (new Dotenv())->loadEnv(__DIR__ . '/../.env');
+    $dotEnv = new Dotenv();
+
+    $dotEnv->loadEnv(__DIR__ . '/../.env');
 }
 
 $_SERVER += $_ENV;

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -20,8 +20,8 @@ require __DIR__ . '/../vendor/autoload.php';
 $environmentVariables = include __DIR__ . '/../.env.local.php';
 
 if (\is_array($environmentVariables) && (!isset($environmentVariables['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $environmentVariables['APP_ENV']) === $environmentVariables['APP_ENV'])) {
-    foreach ($environmentVariables as $name => $v) {
-        $_ENV[$name] = $_ENV[$name] ?? (isset($_SERVER[$name]) && 0 !== \mb_strpos($name, 'HTTP_') ? $_SERVER[$name] : $v);
+    foreach ($environmentVariables as $name => $value) {
+        $_ENV[$name] = $_ENV[$name] ?? (isset($_SERVER[$name]) && 0 !== \mb_strpos($name, 'HTTP_') ? $_SERVER[$name] : $value);
     }
 } elseif (!\class_exists(Dotenv::class)) {
     throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -21,7 +21,13 @@ $environmentVariables = include __DIR__ . '/../.env.local.php';
 
 if (\is_array($environmentVariables) && (!isset($environmentVariables['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $environmentVariables['APP_ENV']) === $environmentVariables['APP_ENV'])) {
     foreach ($environmentVariables as $name => $value) {
-        $_ENV[$name] = $_ENV[$name] ?? (isset($_SERVER[$name]) && 0 !== \mb_strpos($name, 'HTTP_') ? $_SERVER[$name] : $value);
+        if (isset($_ENV['name'])) {
+            $value = $_ENV['name'];
+        } elseif (isset($_SERVER[$name]) && 0 !== \mb_strpos($name, 'HTTP_')) {
+            $value = $_SERVER[$name];
+        }
+
+        $_ENV[$name] = $value;
     }
 } else {
     // load all the .env files

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -20,8 +20,8 @@ require __DIR__ . '/../vendor/autoload.php';
 $environmentVariables = include __DIR__ . '/../.env.local.php';
 
 if (\is_array($environmentVariables) && (!isset($environmentVariables['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $environmentVariables['APP_ENV']) === $environmentVariables['APP_ENV'])) {
-    foreach ($environmentVariables as $k => $v) {
-        $_ENV[$k] = $_ENV[$k] ?? (isset($_SERVER[$k]) && 0 !== \mb_strpos($k, 'HTTP_') ? $_SERVER[$k] : $v);
+    foreach ($environmentVariables as $name => $v) {
+        $_ENV[$name] = $_ENV[$name] ?? (isset($_SERVER[$name]) && 0 !== \mb_strpos($name, 'HTTP_') ? $_SERVER[$name] : $v);
     }
 } elseif (!\class_exists(Dotenv::class)) {
     throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,7 +17,9 @@ require __DIR__ . '/../vendor/autoload.php';
 
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
-if (\is_array($env = include __DIR__ . '/../.env.local.php') && (!isset($env['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV']) === $env['APP_ENV'])) {
+$env = include __DIR__ . '/../.env.local.php';
+
+if (\is_array($env) && (!isset($env['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV']) === $env['APP_ENV'])) {
     foreach ($env as $k => $v) {
         $_ENV[$k] = $_ENV[$k] ?? (isset($_SERVER[$k]) && 0 !== \mb_strpos($k, 'HTTP_') ? $_SERVER[$k] : $v);
     }

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -37,6 +37,11 @@ if (\is_array($environmentVariables) && (!isset($environmentVariables['APP_ENV']
 }
 
 $_SERVER += $_ENV;
-$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
+
+$environment = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
+
+$_SERVER['APP_ENV'] = $environment;
+$_ENV['APP_ENV'] = $environment;
+
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || \filter_var($_SERVER['APP_DEBUG'], \FILTER_VALIDATE_BOOLEAN) ? '1' : '0';

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -40,7 +40,7 @@ $_SERVER += $_ENV;
 
 $environment = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null;
 
-if (!$environment) {
+if (!\is_string($environment) || '' === $environment) {
     $environment = 'dev';
 }
 

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -48,4 +48,8 @@ $_SERVER['APP_ENV'] = $environment;
 $_ENV['APP_ENV'] = $environment;
 
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
-$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || \filter_var($_SERVER['APP_DEBUG'], \FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+
+$debug = (int) $_SERVER['APP_DEBUG'] || \filter_var($_SERVER['APP_DEBUG'], \FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+
+$_SERVER['APP_DEBUG'] = $debug;
+$_ENV['APP_DEBUG'] = $debug;

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -23,8 +23,6 @@ if (\is_array($environmentVariables) && (!isset($environmentVariables['APP_ENV']
     foreach ($environmentVariables as $name => $value) {
         $_ENV[$name] = $_ENV[$name] ?? (isset($_SERVER[$name]) && 0 !== \mb_strpos($name, 'HTTP_') ? $_SERVER[$name] : $value);
     }
-} elseif (!\class_exists(Dotenv::class)) {
-    throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
 } else {
     // load all the .env files
     (new Dotenv())->loadEnv(__DIR__ . '/../.env');

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -38,7 +38,11 @@ if (\is_array($environmentVariables) && (!isset($environmentVariables['APP_ENV']
 
 $_SERVER += $_ENV;
 
-$environment = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
+$environment = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null;
+
+if (!$environment) {
+    $environment = 'dev';
+}
 
 $_SERVER['APP_ENV'] = $environment;
 $_ENV['APP_ENV'] = $environment;

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 use Symfony\Component\Dotenv\Dotenv;
 
-require \dirname(__DIR__) . '/vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
-if (\is_array($env = include \dirname(__DIR__) . '/.env.local.php') && (!isset($env['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV']) === $env['APP_ENV'])) {
+if (\is_array($env = include __DIR__ . '/../.env.local.php') && (!isset($env['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV']) === $env['APP_ENV'])) {
     foreach ($env as $k => $v) {
         $_ENV[$k] = $_ENV[$k] ?? (isset($_SERVER[$k]) && 0 !== \mb_strpos($k, 'HTTP_') ? $_SERVER[$k] : $v);
     }
@@ -25,7 +25,7 @@ if (\is_array($env = include \dirname(__DIR__) . '/.env.local.php') && (!isset($
     throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
 } else {
     // load all the .env files
-    (new Dotenv())->loadEnv(\dirname(__DIR__) . '/.env');
+    (new Dotenv())->loadEnv(__DIR__ . '/../.env');
 }
 
 $_SERVER += $_ENV;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: config/bootstrap.php
 
 		-
-			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
-			count: 1
-			path: config/bootstrap.php
-
-		-
 			message: "#^Only booleans are allowed in \\|\\|, int given on the left side\\.$#"
 			count: 1
 			path: config/bootstrap.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,7 +7,7 @@ parameters:
 
 		-
 			message: "#^Language construct isset\\(\\) should not be used\\.$#"
-			count: 2
+			count: 3
 			path: config/bootstrap.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14,11 +14,13 @@
     </MixedOperand>
   </file>
   <file src="config/bootstrap.php">
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="6">
       <code>$_ENV[$name]</code>
       <code>$_ENV['APP_ENV']</code>
       <code>$_SERVER['APP_DEBUG']</code>
       <code>$_SERVER['APP_ENV']</code>
+      <code>$value</code>
+      <code>$value</code>
     </MixedAssignment>
     <RedundantCondition occurrences="1">
       <code>\is_array($environmentVariables)</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14,11 +14,12 @@
     </MixedOperand>
   </file>
   <file src="config/bootstrap.php">
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="7">
       <code>$_ENV[$name]</code>
       <code>$_ENV['APP_ENV']</code>
       <code>$_SERVER['APP_DEBUG']</code>
       <code>$_SERVER['APP_ENV']</code>
+      <code>$environment</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -21,7 +21,7 @@
       <code>$_SERVER['APP_ENV']</code>
     </MixedAssignment>
     <RedundantCondition occurrences="1">
-      <code>\is_array($env = include __DIR__ . '/../.env.local.php')</code>
+      <code>\is_array($env)</code>
     </RedundantCondition>
   </file>
   <file src="public/index.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7,10 +7,10 @@
     <MixedAssignment occurrences="3">
       <code>$_ENV['APP_ENV']</code>
       <code>$_SERVER['APP_ENV']</code>
-      <code>$env</code>
+      <code>$environment</code>
     </MixedAssignment>
     <MixedOperand occurrences="1">
-      <code>$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env</code>
+      <code>$environment</code>
     </MixedOperand>
   </file>
   <file src="config/bootstrap.php">
@@ -21,7 +21,7 @@
       <code>$_SERVER['APP_ENV']</code>
     </MixedAssignment>
     <RedundantCondition occurrences="1">
-      <code>\is_array($env = include \dirname(__DIR__) . '/.env.local.php')</code>
+      <code>\is_array($env = include __DIR__ . '/../.env.local.php')</code>
     </RedundantCondition>
   </file>
   <file src="public/index.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -21,7 +21,7 @@
       <code>$_SERVER['APP_ENV']</code>
     </MixedAssignment>
     <RedundantCondition occurrences="1">
-      <code>\is_array($env)</code>
+      <code>\is_array($environmentVariables)</code>
     </RedundantCondition>
   </file>
   <file src="public/index.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -15,7 +15,7 @@
   </file>
   <file src="config/bootstrap.php">
     <MixedAssignment occurrences="4">
-      <code>$_ENV[$k]</code>
+      <code>$_ENV[$name]</code>
       <code>$_ENV['APP_ENV']</code>
       <code>$_SERVER['APP_DEBUG']</code>
       <code>$_SERVER['APP_ENV']</code>


### PR DESCRIPTION
This PR

* [x] cleans up code shipped with `symfony/website-skeleton`

💁‍♂️ I have been considering to keep it as it is, but I find it difficult to understand, and thus even more difficult to maintain.