### PR TITLE
Fix: Exclude more files from static code analysis

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^File is missing a \"declare\\(strict_types\\=1\\)\" declaration\\.$#"
-			count: 1
-			path: bin/console
-
-		-
 			message: "#^Language construct isset\\(\\) should not be used\\.$#"
 			count: 2
 			path: config/bootstrap.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,12 +11,9 @@ parameters:
 	inferPrivatePropertyTypeFromConstructor: true
 	level: max
 	paths:
-		- bin/
 		- config/
 		- src/
 		- test/
-		- public/index.php
-		- bin/console
 	symfony:
 		container_xml_path: var/cache/test/Ergebnis_Application_KernelTestDebugContainer.xml
 	tmpDir: .build/phpstan/

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,18 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.18.2@19aa905f7c3c7350569999a93c40ae91ae4e1626">
-  <file src="bin/console">
-    <MixedArgument occurrences="1">
-      <code>$_SERVER['APP_ENV']</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="3">
-      <code>$_ENV['APP_ENV']</code>
-      <code>$_SERVER['APP_ENV']</code>
-      <code>$env</code>
-    </MixedAssignment>
-    <MixedOperand occurrences="1">
-      <code>$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env</code>
-    </MixedOperand>
-  </file>
   <file src="config/bootstrap.php">
     <MixedAssignment occurrences="4">
       <code>$_ENV[$k]</code>
@@ -23,16 +10,6 @@
     <RedundantCondition occurrences="1">
       <code>\is_array($env = include \dirname(__DIR__) . '/.env.local.php')</code>
     </RedundantCondition>
-  </file>
-  <file src="public/index.php">
-    <MixedArgument occurrences="2">
-      <code>$_SERVER['APP_ENV']</code>
-      <code>$trustedProxies</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="2">
-      <code>$trustedHosts</code>
-      <code>$trustedProxies</code>
-    </MixedAssignment>
   </file>
   <file src="src/Kernel.php">
     <MixedAssignment occurrences="2">

--- a/psalm.xml
+++ b/psalm.xml
@@ -23,13 +23,11 @@
     </plugins>
 
     <projectFiles>
-        <directory name="bin/" />
         <directory name="config/" />
         <directory name="src/" />
         <directory name="test/" />
-        <file name="bin/console" />
-        <file name="public/index.php" />
         <ignoreFiles>
+            <directory name="var/" />
             <directory name="vendor/" />
         </ignoreFiles>
     </projectFiles>


### PR DESCRIPTION
This PR

* [x] excludes more files from static code analysis (especially those coming from `symfony/symfony`
* [x] runs `make static-code-analysis-baseline`