### PR TITLE
Fix: Use entry points as shipped with symfony/symfony

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,10 +2,10 @@
 <?php
 
 use App\Kernel;
-use Symfony\Bundle\FrameworkBundle;
-use Symfony\Component\Console;
-use Symfony\Component\Dotenv;
-use Symfony\Component\ErrorHandler;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\ErrorHandler\Debug;
 
 if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
     echo 'Warning: The console should be invoked via the CLI version of PHP, not the ' . \PHP_SAPI . ' SAPI' . \PHP_EOL;
@@ -15,11 +15,11 @@ if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
 
 require \dirname(__DIR__) . '/vendor/autoload.php';
 
-if (!\class_exists(FrameworkBundle\Console\Application::class) || !\class_exists(Dotenv\Dotenv::class)) {
-    throw new LogicException('You need to add "symfony/framework-bundle" as a Composer dependencies.');
+if (!\class_exists(Application::class) || !\class_exists(Dotenv::class)) {
+    throw new LogicException('You need to add "symfony/framework-bundle" and "symfony/dotenv" as Composer dependencies.');
 }
 
-$input = new Console\Input\ArgvInput();
+$input = new ArgvInput();
 
 if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
     \putenv('APP_ENV=' . $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
@@ -29,21 +29,16 @@ if ($input->hasParameterOption('--no-debug', true)) {
     \putenv('APP_DEBUG=' . $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
 }
 
-(new Dotenv\Dotenv())->bootEnv(\dirname(__DIR__) . '/.env');
+(new Dotenv())->bootEnv(\dirname(__DIR__) . '/.env');
 
 if ($_SERVER['APP_DEBUG']) {
     \umask(0000);
 
-    if (\class_exists(ErrorHandler\Debug::class)) {
-        ErrorHandler\Debug::enable();
+    if (\class_exists(Debug::class)) {
+        Debug::enable();
     }
 }
 
-$kernel = new Kernel(
-    $_SERVER['APP_ENV'],
-    (bool) $_SERVER['APP_DEBUG']
-);
-
-$application = new FrameworkBundle\Console\Application($kernel);
-
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$application = new Application($kernel);
 $application->run($input);

--- a/public/index.php
+++ b/public/index.php
@@ -12,43 +12,30 @@ declare(strict_types=1);
  */
 
 use App\Kernel;
-use Symfony\Component\Dotenv;
-use Symfony\Component\ErrorHandler;
-use Symfony\Component\HttpFoundation;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\ErrorHandler\Debug;
+use Symfony\Component\HttpFoundation\Request;
 
 require \dirname(__DIR__) . '/vendor/autoload.php';
 
-(new Dotenv\Dotenv())->bootEnv(\dirname(__DIR__) . '/.env');
+(new Dotenv())->bootEnv(\dirname(__DIR__) . '/.env');
 
 if ($_SERVER['APP_DEBUG']) {
     \umask(0000);
 
-    ErrorHandler\Debug::enable();
+    Debug::enable();
 }
 
-if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false) {
-    HttpFoundation\Request::setTrustedProxies(
-        \explode(',', $trustedProxies),
-        HttpFoundation\Request::HEADER_X_FORWARDED_ALL ^ HttpFoundation\Request::HEADER_X_FORWARDED_HOST
-    );
+if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? false) {
+    Request::setTrustedProxies(\explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO);
 }
 
-if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false) {
-    HttpFoundation\Request::setTrustedHosts([$trustedHosts]);
+if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? false) {
+    Request::setTrustedHosts([$trustedHosts]);
 }
 
-$kernel = new Kernel(
-    $_SERVER['APP_ENV'],
-    (bool) $_SERVER['APP_DEBUG']
-);
-
-$request = HttpFoundation\Request::createFromGlobals();
-
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$request = Request::createFromGlobals();
 $response = $kernel->handle($request);
-
 $response->send();
-
-$kernel->terminate(
-    $request,
-    $response
-);
+$kernel->terminate($request, $response);


### PR DESCRIPTION
This PR

* [x] uses entry points as shipped with `symfony/symfony`

🤷‍♂️ 