### PR TITLE
Fix: Require symplify/config-transformer instead of migrify/config-transformer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,6 @@
     "ergebnis/phpstan-rules": "~0.15.3",
     "ergebnis/test-util": "^1.3.0",
     "infection/infection": "~0.20",
-    "migrify/config-transformer": "~9.0.23",
     "phpstan/extension-installer": "^1.1.0",
     "phpstan/phpstan": "~0.12.64",
     "phpstan/phpstan-deprecation-rules": "~0.12.6",
@@ -67,6 +66,7 @@
     "phpunit/phpunit": "^9.2.6",
     "psalm/plugin-phpunit": "~0.12.2",
     "psalm/plugin-symfony": "^1.5.0",
+    "symplify/config-transformer": "^9.0.23",
     "vimeo/psalm": "^3.18",
     "weirdan/doctrine-psalm-plugin": "~0.11.3"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae635bba1794c89e6f5243dfa4560268",
+    "content-hash": "d206d84517e309ad89415537a5e33da4",
     "packages": [
         {
             "name": "brick/math",
@@ -6144,55 +6144,6 @@
             "time": "2020-07-06T04:49:32+00:00"
         },
         {
-            "name": "migrify/config-transformer",
-            "version": "9.0.23",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symplify/config-transformer.git",
-                "reference": "2c4da8108884f24bc52fe2ec787f8c428671fd6f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symplify/config-transformer/zipball/2c4da8108884f24bc52fe2ec787f8c428671fd6f",
-                "reference": "2c4da8108884f24bc52fe2ec787f8c428671fd6f",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "nette/neon": "^3.2",
-                "nette/utils": "^3.0",
-                "nikic/php-parser": "^4.10.4",
-                "php": ">=7.3",
-                "symfony/console": "^4.4|^5.1",
-                "symfony/dependency-injection": "^5.1",
-                "symfony/expression-language": "^4.4|^5.1",
-                "symfony/http-kernel": "^4.4|^5.1",
-                "symfony/yaml": "^4.4|^5.1",
-                "symplify/php-config-printer": "^9.0.23"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "symfony/framework-bundle": "^4.4|^5.1",
-                "symplify/easy-testing": "^9.0.23"
-            },
-            "bin": [
-                "bin/config-transformer"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symplify\\ConfigTransformer\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Convert Symfony YAML/XML format to PHP/YAML",
-            "abandoned": "symplify/config-transformer",
-            "time": "2020-12-30T00:58:30+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
             "version": "1.10.1",
             "source": {
@@ -6353,6 +6304,10 @@
                 "iterator",
                 "nette"
             ],
+            "support": {
+                "issues": "https://github.com/nette/finder/issues",
+                "source": "https://github.com/nette/finder/tree/v2.5.2"
+            },
             "time": "2020-01-03T20:35:40+00:00"
         },
         {
@@ -6415,6 +6370,10 @@
                 "nette",
                 "yaml"
             ],
+            "support": {
+                "issues": "https://github.com/nette/neon/issues",
+                "source": "https://github.com/nette/neon/tree/master"
+            },
             "time": "2020-07-31T12:28:05+00:00"
         },
         {
@@ -6496,6 +6455,10 @@
                 "utility",
                 "validation"
             ],
+            "support": {
+                "issues": "https://github.com/nette/utils/issues",
+                "source": "https://github.com/nette/utils/tree/v3.2.0"
+            },
             "time": "2020-11-25T23:47:50+00:00"
         },
         {
@@ -8859,6 +8822,9 @@
             ],
             "description": "Symfony ExpressionLanguage Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/expression-language/tree/v5.2.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -9039,6 +9005,9 @@
                 "MIT"
             ],
             "description": "Autowire array parameters for your Symfony applications",
+            "support": {
+                "source": "https://github.com/symplify/autowire-array-parameter/tree/9.0.23"
+            },
             "funding": [
                 {
                     "url": "https://www.paypal.me/rectorphp",
@@ -9094,6 +9063,9 @@
                 "MIT"
             ],
             "description": "Package to load, merge and save composer.json file(s)",
+            "support": {
+                "source": "https://github.com/symplify/composer-json-manipulator/tree/9.0.23"
+            },
             "funding": [
                 {
                     "url": "https://www.paypal.me/rectorphp",
@@ -9105,6 +9077,57 @@
                 }
             ],
             "time": "2020-12-30T00:58:31+00:00"
+        },
+        {
+            "name": "symplify/config-transformer",
+            "version": "9.0.23",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symplify/config-transformer.git",
+                "reference": "2c4da8108884f24bc52fe2ec787f8c428671fd6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symplify/config-transformer/zipball/2c4da8108884f24bc52fe2ec787f8c428671fd6f",
+                "reference": "2c4da8108884f24bc52fe2ec787f8c428671fd6f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "nette/neon": "^3.2",
+                "nette/utils": "^3.0",
+                "nikic/php-parser": "^4.10.4",
+                "php": ">=7.3",
+                "symfony/console": "^4.4|^5.1",
+                "symfony/dependency-injection": "^5.1",
+                "symfony/expression-language": "^4.4|^5.1",
+                "symfony/http-kernel": "^4.4|^5.1",
+                "symfony/yaml": "^4.4|^5.1",
+                "symplify/php-config-printer": "^9.0.23"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5",
+                "symfony/framework-bundle": "^4.4|^5.1",
+                "symplify/easy-testing": "^9.0.23"
+            },
+            "bin": [
+                "bin/config-transformer"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symplify\\ConfigTransformer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Convert Symfony YAML/XML format to PHP/YAML",
+            "support": {
+                "source": "https://github.com/symplify/config-transformer/tree/9.0.23"
+            },
+            "time": "2020-12-30T00:58:30+00:00"
         },
         {
             "name": "symplify/easy-testing",
@@ -9147,6 +9170,9 @@
                 "MIT"
             ],
             "description": "Testing made easy",
+            "support": {
+                "source": "https://github.com/symplify/easy-testing/tree/9.0.23"
+            },
             "funding": [
                 {
                     "url": "https://www.paypal.me/rectorphp",
@@ -9206,6 +9232,9 @@
                 "MIT"
             ],
             "description": "Dependency Injection, Console and Kernel toolkit for Symplify packages.",
+            "support": {
+                "source": "https://github.com/symplify/package-builder/tree/9.0.23"
+            },
             "funding": [
                 {
                     "url": "https://www.paypal.me/rectorphp",
@@ -9259,6 +9288,10 @@
                 "MIT"
             ],
             "description": "Print Symfony services array with configuration to to plain PHP file format thanks to this simple php-parser wrapper",
+            "support": {
+                "issues": "https://github.com/symplify/php-config-printer/issues",
+                "source": "https://github.com/symplify/php-config-printer/tree/9.0.23"
+            },
             "time": "2020-12-30T00:58:46+00:00"
         },
         {
@@ -9301,6 +9334,9 @@
                 "MIT"
             ],
             "description": "Sanitized FileInfo with safe getRealPath() and other handy methods",
+            "support": {
+                "source": "https://github.com/symplify/smart-file-system/tree/9.0.23"
+            },
             "funding": [
                 {
                     "url": "https://www.paypal.me/rectorphp",
@@ -9356,6 +9392,10 @@
                 "MIT"
             ],
             "description": "Internal Kernel for Symplify packages",
+            "support": {
+                "issues": "https://github.com/symplify/symplify-kernel/issues",
+                "source": "https://github.com/symplify/symplify-kernel/tree/9.0.23"
+            },
             "time": "2020-12-30T00:58:44+00:00"
         },
         {

--- a/symfony.lock
+++ b/symfony.lock
@@ -189,9 +189,6 @@
     "localheinz/diff": {
         "version": "1.0.1"
     },
-    "migrify/config-transformer": {
-        "version": "v0.3.24"
-    },
     "migrify/migrify-kernel": {
         "version": "0.3.39"
     },
@@ -211,13 +208,10 @@
         "version": "v3.2.1"
     },
     "nette/utils": {
-        "version": "v3.1.3"
+        "version": "v3.2.0"
     },
     "nikic/php-parser": {
         "version": "v4.3.0"
-    },
-    "ocramius/proxy-manager": {
-        "version": "2.8.0"
     },
     "ondram/ci-detector": {
         "version": "3.4.0"
@@ -430,7 +424,7 @@
         "version": "v2.0.1"
     },
     "symfony/expression-language": {
-        "version": "v5.1.3"
+        "version": "v5.2.1"
     },
     "symfony/filesystem": {
         "version": "v5.0.4"
@@ -536,25 +530,28 @@
         "version": "v5.0.4"
     },
     "symplify/autowire-array-parameter": {
-        "version": "v8.2.1"
+        "version": "9.0.23"
     },
     "symplify/composer-json-manipulator": {
-        "version": "9.0.1"
+        "version": "9.0.23"
+    },
+    "symplify/config-transformer": {
+        "version": "9.0.23"
     },
     "symplify/easy-testing": {
-        "version": "9.0.1"
+        "version": "9.0.23"
     },
     "symplify/package-builder": {
-        "version": "v8.2.1"
+        "version": "9.0.23"
     },
     "symplify/php-config-printer": {
-        "version": "9.0.1"
+        "version": "9.0.23"
     },
     "symplify/smart-file-system": {
-        "version": "v8.2.1"
+        "version": "9.0.23"
     },
     "symplify/symplify-kernel": {
-        "version": "8.3.33"
+        "version": "9.0.23"
     },
     "thecodingmachine/safe": {
         "version": "v1.0.3"
@@ -564,9 +561,6 @@
     },
     "vimeo/psalm": {
         "version": "3.9.3"
-    },
-    "webimpress/safe-writer": {
-        "version": "2.0.1"
     },
     "webmozart/assert": {
         "version": "1.7.0"


### PR DESCRIPTION
This PR

* [x] requires `symplify/config-transformer` instead of the abandoned `migrify/config-transformer`