### PR TITLE
Fix: Migrate configuration for phpunit/phpunit

### DIFF
--- a/test/Unit/phpunit.xml
+++ b/test/Unit/phpunit.xml
@@ -27,12 +27,12 @@
             <directory>.</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="true">
+    <coverage includeUncoveredFiles="true" processUncoveredFiles="true">
+        <exclude>
+            <file>../../src/Kernel.php</file>
+        </exclude>
+        <include>
             <directory suffix=".php">../../src/</directory>
-            <exclude>
-                <file>../../src/Kernel.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
This PR

* [x] migrates the configuration for `phpunit/phpunit`