### PR TITLE
Fix: Do not cache cache directory for vimeo/psalm

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -274,13 +274,6 @@ jobs:
       - name: "Create cache directory for vimeo/psalm"
         run: "mkdir -p .build/psalm"
 
-      - name: "Cache cache directory for vimeo/psalm"
-        uses: "actions/cache@v2.1.7"
-        with:
-          path: ".build/psalm"
-          key: "php-${{ matrix.php-version }}-psalm-${{ github.sha }}"
-          restore-keys: "php-${{ matrix.php-version }}-psalm-"
-
       - name: "Run vimeo/psalm"
         run: "vendor/bin/psalm --config=psalm.xml --diff --shepherd --show-info=false --stats --threads=4"
 

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ static-code-analysis: vendor cache ## Runs a static code analysis with vimeo/psa
 .PHONY: static-code-analysis-baseline
 static-code-analysis-baseline: vendor cache ## Generates a baseline for static code analysis with vimeo/psalm
 	mkdir -p .build/psalm
+	vendor/bin/psalm --config=psalm.xml --clear-cache
 	vendor/bin/psalm --config=psalm.xml --set-baseline=psalm-baseline.xml
 
 .PHONY: tests


### PR DESCRIPTION
This pull request

* [x] stops caching the cache directory for `vimeo/psalm`