### PR TITLE
Fix: Do not suggest to use `pcov`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -89,7 +89,7 @@ to run all the tests.
 
 We are using [`infection/infection`](https://github.com/infection/infection) to ensure a minimum quality of the tests.
 
-Enable `pcov` or `Xdebug` and run
+Enable `Xdebug` and run
 
 ```sh
 make mutation-tests


### PR DESCRIPTION
This pull request

- [x] stops suggesting to use `pcov`