### PR TITLE
Fix: Do not use --diff option

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -275,7 +275,7 @@ jobs:
         run: "mkdir -p .build/psalm"
 
       - name: "Run vimeo/psalm"
-        run: "vendor/bin/psalm --config=psalm.xml --diff --shepherd --show-info=false --stats --threads=4"
+        run: "vendor/bin/psalm --config=psalm.xml --shepherd --show-info=false --stats --threads=4"
 
   symfony-flex:
     name: "Symfony Flex"


### PR DESCRIPTION
This pull request

- [x] stops using the `--diff` option as it has no effect with a cold cache