### PR TITLE
Enhancement: Allow dependabot to update all dependencies for composer

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,9 @@
 version: 2
 
 updates:
-  - commit-message:
+  - allow:
+      dependency-type: "all"
+    commit-message:
       include: "scope"
       prefix: "composer"
     directory: "/"


### PR DESCRIPTION
This pull request

- [x] allows dependabot to update all dependencies for `composer`

Follows https://github.com/ergebnis/php-package-template/issues/845.

💁‍♂️ For reference, see https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#allow.
