### PR TITLE
Fix: Set `XDEBUG_MODE` to `coverage` when collecting code coverage

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -55,6 +55,8 @@ jobs:
           dependencies: "${{ matrix.dependencies }}"
 
       - name: "Collect code coverage with Xdebug and phpunit/phpunit"
+        env:
+          XDEBUG_MODE: "coverage"
         run: "vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-clover=.build/phpunit/logs/clover.xml"
 
       - name: "Send code coverage report to Codecov.io"
@@ -221,6 +223,8 @@ jobs:
         run: "bin/console cache:warmup"
 
       - name: "Run mutation tests with Xdebug and infection/infection"
+        env:
+          XDEBUG_MODE: "coverage"
         run: "vendor/bin/infection --configuration=infection.json --logger-github"
 
   static-code-analysis:


### PR DESCRIPTION
This pull request

- [x] sets `XDEBUG_MODE` to `coverage` when collecting code coverage