### PR TITLE
Fix: Require `ext-pdo_pgsql`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "ext-iconv": "*",
     "ext-mbstring": "*",
     "ext-pdo": "*",
+    "ext-pdo_pgsql": "*",
     "doctrine/annotations": "^1.13.2",
     "doctrine/collections": "^1.6.8",
     "doctrine/doctrine-bundle": "^2.5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a003db6ebb8fa5eed32df1d004ae9d0b",
+    "content-hash": "eca28453f18cb53f0582d4ed71f0c3a6",
     "packages": [
         {
             "name": "brick/math",
@@ -9015,7 +9015,8 @@
         "ext-ctype": "*",
         "ext-iconv": "*",
         "ext-mbstring": "*",
-        "ext-pdo": "*"
+        "ext-pdo": "*",
+        "ext-pdo_pgsql": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
This pull request

- [x] requires `ext-pdo_pgsql`

Follows #902.