### PR TITLE
Fix: Use `~` operator to limit compatibility with PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "source": "https://github.com/ergebnis/symfony-application-template"
   },
   "require": {
-    "php": "^8.1",
+    "php": "~8.1.0",
     "ext-ctype": "*",
     "ext-iconv": "*",
     "ext-mbstring": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8043f0481abb68e7cdde98be258ce16d",
+    "content-hash": "d5b32051989d55cd2cee7c69c5c40ce1",
     "packages": [
         {
             "name": "brick/math",
@@ -8933,7 +8933,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1",
+        "php": "~8.1.0",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "ext-mbstring": "*",


### PR DESCRIPTION
This pull request

- [x] uses the `~` operator to limit the compatibility with PHP versions 

Follows https://github.com/ergebnis/php-package-template/pull/1086.